### PR TITLE
Optionally log more stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "vscode-marketplace-ext-stats",
+  "version": "1.0.0",
+  "description": "[VSCode Marketplace](https://marketplace.visualstudio.com/vscode) **Extension Stats** tool anyone with  [nodejs](https://nodejs.org/en/download/) installed can run 🏃 to get periodic Installs & Downloads counts for Visual Studio family of products extensions.",
+  "type": "module",
+  "main": "tools/vscode-marketplace-stats.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RandomFractals/vscode-marketplace-ext-stats.git"
+  },
+  "keywords": [],
+  "author": "Taras Novak, Random Fractals Inc.",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/RandomFractals/vscode-marketplace-ext-stats/issues"
+  },
+  "homepage": "https://github.com/RandomFractals/vscode-marketplace-ext-stats#readme"
+}


### PR DESCRIPTION
## :warning: WIP

There are some additional stats being returned that could be logged:

```
averagerating
ratingcount
trendingdaily
trendingmonthly
trendingweekly
weightedRating
```

This is a POC of how it could be done.  It defaults to logging the existing stats. If you uncomment [lines 22-23](https://github.com/mrienstra/vscode-marketplace-ext-stats/blob/3ef1fa2/tools/vscode-marketplace-stats.js#L22-L23), it will then also track `trendingweekly` & `trendingdaily`.

If there is an existing ``` `${extensionName}-stats-${isoDateString}.csv` ``` file with matching CSV headers, it will write to it. If the headers are wrong, it will append a number to the end, incrementing this number as needed: ``` `${extensionName}-stats-${isoDateString}_${suffix++}.csv` ```

---

Some of the changes (the most glaring being the switch from `require` to `import`) are due to the use of a top-level `await`.

I added a `package.json` (`npm init -y`, then changed `license` and `author`), again to support  the use of a top-level `await`.

[Line 5](https://github.com/mrienstra/vscode-marketplace-ext-stats/blob/3ef1fa2/package.json#L5): `"type": "module",` does the magic. See https://www.google.com/search?q=top+level+await+type+module+package.json